### PR TITLE
optional hint added

### DIFF
--- a/imposter-game/src/components/ImposterGame/ImposterGame.jsx
+++ b/imposter-game/src/components/ImposterGame/ImposterGame.jsx
@@ -4,6 +4,16 @@ import s from "./ImposterGame.module.css";
 import InstructionManual from "./InstructionManual";
 import bgMusic from "../../assets/imposter.mp3";
 
+
+const generateHint = (word) => {
+  const hints = [
+    `Starts with "${word[0]}"`,
+    `Word length: ${word.length}`
+  ];
+
+  return hints[Math.floor(Math.random() * hints.length)];
+};
+
 export default function ImposterGame() {
   const [phase, setPhase] = useState("setup");
   const [playerCount, setPlayerCount] = useState(4);
@@ -15,7 +25,7 @@ export default function ImposterGame() {
   const [selectedCard, setSelectedCard] = useState(null);
   const [showManual, setShowManual] = useState(false);
   const [suspect, setSuspect] = useState(null);
-
+  const [showHint,setShowHint]=useState(false);
   const [musicOn, setMusicOn] = useState(true);
   const audioRef = useRef(null);
 
@@ -65,17 +75,23 @@ export default function ImposterGame() {
   };
 
   const startGame = useCallback(() => {
-    const players = playerNames.slice(0, playerCount).map((n) => n.trim());
-    const roles = assignRoles(players, selectedGenre);
-    setGameData({ ...roles, players });
-    setFlipped([]);
-    setSeen([]);
-    setSelectedCard(null);
-    setSuspect(null);
-    setPhase("cards");
-    setStartingPlayerIndex(null);
-    setShowStarter(false);
-  }, [playerNames, playerCount, selectedGenre]);
+  const players = playerNames.slice(0, playerCount).map((n) => n.trim());
+  const roles = assignRoles(players, selectedGenre);
+
+  let hint = null;
+
+  if (showHint) {
+    hint = generateHint(roles.word, roles.genre);
+  }
+
+  setGameData({ ...roles, players, hint });
+  setFlipped([]);
+  setSeen([]);
+  setSelectedCard(null);
+  setPhase("cards");
+  setStartingPlayerIndex(null);
+  setShowStarter(false);
+}, [playerNames, playerCount, selectedGenre, showHint]);
 
   const handleFlip = (i) => {
     if (flipped.includes(i)) {
@@ -167,16 +183,27 @@ export default function ImposterGame() {
             </button>
             {showManual && <InstructionManual onClose={() => setShowManual(false)} />}
 
-            <button className={s.startBtn} disabled={!canStart} onClick={startGame}>
-              Start Game
-            </button>
+            <div style={{ marginBottom: "10px" }}>
+  <label>
+    <input
+      type="checkbox"
+      checked={showHint}
+      onChange={() => setShowHint(!showHint)}
+    />
+    {" "}Show hint to imposter
+  </label>
+</div>
+
+<button className={s.startBtn} disabled={!canStart} onClick={startGame}>
+  Start Game
+</button>
           </div>
         ) : phase === "cards" ? (
           <div className={s.gameView}>
             <div className={s.phaseBadge}>🃏 Reveal Phase</div>
             <div className={s.phaseHint}>Each player, tap your card privately to see your role.</div>
 
-            {/* FULLSCREEN OVERLAY: Shows only when a card is selected */}
+            
             {selectedCard !== null && (
               <div className={s.fullscreenOverlay} onClick={() => handleFlip(selectedCard)}>
                 <div className={s.focusedCardWrapper}>
@@ -187,8 +214,13 @@ export default function ImposterGame() {
                           {selectedCard === gameData.imposterIndex ? "⚠ You Are" : "Your Word"}
                         </div>
                         <div className={s.revealWord}>
-                          {selectedCard === gameData.imposterIndex ? "IMPOSTER" : gameData.word}
-                        </div>
+  {selectedCard === gameData.imposterIndex ? "IMPOSTER" : gameData.word}
+</div>
+{selectedCard === gameData.imposterIndex && showHint && gameData.hint && (
+  <div style={{ marginTop: "10px", fontSize: "14px", opacity: 0.8 }}>
+    Hint: {gameData.hint}
+  </div>
+)}
                         {selectedCard !== gameData.imposterIndex && (
                           <div className={s.revealGenre}>
                             {gameData.genre.split(" ").slice(1).join(" ")}


### PR DESCRIPTION
## 📌 Description

This PR introduces an optional **Hint System for the Imposter** to improve gameplay experience, especially for new or casual players. Since the genre is already visible to all players, the hint system provides **partial word-based clues** (like first letter or word length) instead of redundant category hints. This helps the imposter participate more effectively without compromising game balance.

---

## 🔗 Related Issue

Closes #17 

---

## 🛠 Changes Made

* Added a **"Show hint to imposter" toggle** in the game setup screen
* Implemented a **dynamic hint generation system** based on:

  * First letter of the word
  * Word length
* Stored hint in `gameData` during game initialization
* Displayed hint **only to the imposter** during card reveal phase
* Ensured hints are **hidden from other players**
* Improved hint logic to avoid redundant genre-based hints

---

## 📷 Screenshots (if applicable)

(Add before/after screenshots of:
<img width="1368" height="768" alt="image" src="https://github.com/user-attachments/assets/166a82ad-db30-41cb-95d8-378ef477d432" />

<img width="1368" height="768" alt="image" src="https://github.com/user-attachments/assets/e88852a3-7cce-4c52-a190-64ae6d7c1229" />
---

## ✅ Checklist

* [x] I have tested my changes
* [x] My code follows project guidelines
* [x] I have linked the related issue
