### PR TITLE
timer added

### DIFF
--- a/imposter-game/src/components/ImposterGame/ImposterGame.jsx
+++ b/imposter-game/src/components/ImposterGame/ImposterGame.jsx
@@ -15,7 +15,8 @@ export default function ImposterGame() {
   const [selectedCard, setSelectedCard] = useState(null);
   const [showManual, setShowManual] = useState(false);
   const [suspect, setSuspect] = useState(null);
-
+  const [timerDuration, setTimerDuration] = useState(2); // in minutes
+  const [timeLeft, setTimeLeft] = useState(null);
   const [musicOn, setMusicOn] = useState(true);
   const audioRef = useRef(null);
 
@@ -103,6 +104,24 @@ export default function ImposterGame() {
       setShowStarter(true);
     }
   }, [allSeen, gameData, startingPlayerIndex]);
+  useEffect(() => {
+  if (phase !== "discussion" || timeLeft === null) return;
+  if (timeLeft <= 0) return;
+
+  const interval = setInterval(() => {
+    setTimeLeft((prev) => {
+      if (prev <= 1) {
+        clearInterval(interval);
+        const audio = new Audio("https://www.soundjay.com/buttons/beep-01a.mp3");
+        audio.play().catch(() => {});
+        return 0;
+      }
+      return prev - 1;
+    });
+  }, 1000);
+
+  return () => clearInterval(interval);
+}, [phase, timeLeft]);
   return (
     <div className={s.app}>
       <div className={s.bgGrid} />
@@ -162,6 +181,20 @@ export default function ImposterGame() {
                 ))}
               </div>
             </div>
+            <div className={s.card}>
+  <div className={s.sectionLabel}>Discussion Timer</div>
+  <div className={s.playerCountRow}>
+    {[1, 2, 3, 5].map((min) => (
+      <button
+        key={min}
+        className={`${s.genreBtn} ${timerDuration === min ? s.genreBtnSelected : ""}`}
+        onClick={() => setTimerDuration(min)}
+      >
+        {min} min
+      </button>
+    ))}
+  </div>
+</div>
             <button className={s.manualBtn} onClick={() => setShowManual(true)}>
               Show Instructions
             </button>
@@ -174,8 +207,40 @@ export default function ImposterGame() {
         ) : phase === "cards" ? (
           <div className={s.gameView}>
             <div className={s.phaseBadge}>🃏 Reveal Phase</div>
-            <div className={s.phaseHint}>Each player, tap your card privately to see your role.</div>
-
+            {timeLeft !== null && (
+  <div style={{ textAlign: "center", margin: "1rem 0" }}>
+    <div style={{
+      fontSize: "4rem",
+      fontWeight: "bold",
+      color: timeLeft <= 30 ? "#ff4444" : timeLeft <= 60 ? "#ffaa00" : "#00ffcc",
+      transition: "color 0.5s"
+    }}>
+      {String(Math.floor(timeLeft / 60)).padStart(2, "0")}:
+      {String(timeLeft % 60).padStart(2, "0")}
+    </div>
+    <div style={{
+      background: "#1a1a2e",
+      borderRadius: "8px",
+      height: "10px",
+      width: "100%",
+      maxWidth: "300px",
+      margin: "0.5rem auto"
+    }}>
+      <div style={{
+        height: "100%",
+        borderRadius: "8px",
+        width: `${(timeLeft / (timerDuration * 60)) * 100}%`,
+        background: timeLeft <= 30 ? "#ff4444" : timeLeft <= 60 ? "#ffaa00" : "#00ffcc",
+        transition: "width 1s linear, background 0.5s"
+      }} />
+    </div>
+    {timeLeft === 0 && (
+      <div style={{ fontSize: "1.5rem", color: "#ff4444", marginTop: "0.5rem" }}>
+        ⏰ Time's up! Vote now!
+      </div>
+    )}
+  </div>
+)}
             {/* FULLSCREEN OVERLAY: Shows only when a card is selected */}
             {selectedCard !== null && (
               <div className={s.fullscreenOverlay} onClick={() => handleFlip(selectedCard)}>
@@ -223,7 +288,9 @@ export default function ImposterGame() {
                 )}
                 <button
                   className={s.actionBtn}
-                  onClick={() => setPhase("discussion")}
+                  onClick={() => {setTimeLeft(timerDuration * 60);
+                    setPhase("discussion")
+                  }}
                 >
                   Start Discussion →
                 </button>
@@ -276,7 +343,42 @@ export default function ImposterGame() {
               </div>
             )}
 
-            <div className={s.phaseHint}>Talk to find the imposter!</div>
+            {timeLeft !== null && (
+  <div style={{ textAlign: "center", margin: "1rem 0" }}>
+    <div style={{
+      fontSize: "4rem",
+      fontWeight: "bold",
+      color: timeLeft <= 30 ? "#ff4444" : timeLeft <= 60 ? "#ffaa00" : "#00ffcc",
+      transition: "color 0.5s"
+    }}>
+      {String(Math.floor(timeLeft / 60)).padStart(2, "0")}:
+      {String(timeLeft % 60).padStart(2, "0")}
+    </div>
+    <div style={{
+      background: "#1a1a2e",
+      borderRadius: "8px",
+      height: "10px",
+      width: "100%",
+      maxWidth: "300px",
+      margin: "0.5rem auto"
+    }}>
+      <div style={{
+        height: "100%",
+        borderRadius: "8px",
+        width: `${(timeLeft / (timerDuration * 60)) * 100}%`,
+        background: timeLeft <= 30 ? "#ff4444" : timeLeft <= 60 ? "#ffaa00" : "#00ffcc",
+        transition: "width 1s linear, background 0.5s"
+      }} />
+    </div>
+    {timeLeft === 0 && (
+      <div style={{ fontSize: "1.5rem", color: "#ff4444", marginTop: "0.5rem" }}>
+        ⏰ Time's up! Vote now!
+      </div>
+    )}
+  </div>
+)}
+
+<div className={s.phaseHint}>Talk to find the imposter!</div>
 
             <button
               className={s.resetBtn}


### PR DESCRIPTION
## 📌 Description

Added a configurable countdown timer to the Discussion Phase. Players can now select a duration (1, 2, 3, or 5 minutes) from the setup screen. The timer displays prominently during discussion with a progress bar and color shifts as time runs low, and plays an audio cue when time is up.

---

## 🔗 Related Issue

Closes #18 

---

## 🛠 Changes Made

- Added `timerDuration` and `timeLeft` state variables to `ImposterGame.js`
- Added duration picker UI (1, 2, 3, 5 min buttons) in the setup screen
- Added `useEffect` to handle countdown logic with auto-cleanup
- Timer auto-starts when "Start Discussion →" is clicked via `setTimeLeft(timerDuration * 60)`
- Added timer display in discussion phase with large digits, animated progress bar, and color transitions (green → yellow at 60s → red at 30s)
- Added beep audio cue and "⏰ Time's up! Vote now!" message on expiry

---

## 📷 Screenshots (if applicable)

<img width="1368" height="768" alt="Screenshot from 2026-02-27 07-49-40" src="https://github.com/user-attachments/assets/fe0c13f5-1359-48cd-a3a4-46ceec7d21f2" />
<img width="1368" height="768" alt="image" src="https://github.com/user-attachments/assets/40079db0-d284-403f-a958-5ee9b9856241" />
<img width="1368" height="768" alt="image" src="https://github.com/user-attachments/assets/8ccc78d6-a954-4102-931b-0d0577d94fd5" />
<img width="1368" height="768" alt="Screenshot from 2026-02-27 07-55-22" src="https://github.com/user-attachments/assets/9ce4c5c4-45d1-4681-bf5a-e5157203fa51" />


---

## ✅ Checklist

- [x] I have tested my changes
- [x] My code follows project guidelines
- [x] I have linked the related issue