### PR TITLE
Absolute Path Aliasing solved

### DIFF
--- a/imposter-game/jsconfig.json
+++ b/imposter-game/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/imposter-game/vite.config.js
+++ b/imposter-game/vite.config.js
@@ -1,7 +1,13 @@
+import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  }
 })


### PR DESCRIPTION
## 📌 Description
I have implemented absolute path aliasing for the project.

---

## 🔗 Related Issue
Closes #41 

---

## 🛠 Changes Made
1. Updated imposter-game/vite.config.js
  Added the resolve.alias configuration using modern ESM patterns (node:url) to map @ to the src directory.


    1 import { fileURLToPath, URL } from 'node:url'
    2 import { defineConfig } from 'vite'
    3 import react from '@vitejs/plugin-react'
    4
    5 // https://vite.dev/config/
    6 export default defineConfig({
    7   plugins: [react()],
    8   resolve: {
    9     alias: {
   10       '@': fileURLToPath(new URL('./src', import.meta.url))
   11     }
   12   }
   13 })


  2. Created imposter-game/jsconfig.json
  Added this file to the root of the project to enable IDE features like autocompletion and "Go to Definition" for the @ alias.


   1 {
   2   "compilerOptions": {
   3     "baseUrl": ".",
   4     "paths": {
   5       "@/*": ["./src/*"]
   6     }
   7   },
   8   "include": ["src"]
   9 }## 📷 Screenshots (if applicable)

---

## ✅ Checklist
- [yes ] I have tested my changes
- [yes ] My code follows project guidelines
- [yes ] I have linked the related issue
